### PR TITLE
🚀 chore(package.json): Ubah script "postinstall" menjadi "prepare"

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
         "build:push": "npm run build && git add . && git commit -m 'build' && git push",
         "lint": "eslint src --ext ts && tsc --noEmit",
         "format": "prettier --write .",
-        "postinstall": "npm run build"
+        "prepare": "npm run build"
     },
     "devDependencies": {
         "@types/ini": "^1.3.31",


### PR DESCRIPTION
ℹ️ Mengubah script "postinstall" menjadi "prepare" untuk mengganti hook yang dijalankan setelah instalasi paket selesai. Menjalankan "npm run build" saat mempersiapkan paket akan memastikan bahwa aplikasi telah dibangun dengan benar sebelum digunakan atau didistribusikan.

Ini membantu memastikan bahwa setiap kali paket diinstal, build akan dieksekusi secara otomatis, sehingga pengguna dapat menggunakannya langsung tanpa perlu menjalankan perintah build secara manual.