### PR TITLE
🐛 fix(esbuild.config.js): mengubah penanganan path file saat copy

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -13,14 +13,8 @@ const buildOptions = {
 
 try {
     esbuild.buildSync(buildOptions);
-    const sourceFilePath = path.resolve(
-        path.dirname(fileURLToPath(import.meta.url)),
-        "./src/chat_api_interaction.js"
-    );
-    const destinationFilePath = path.resolve(
-        path.dirname(fileURLToPath(import.meta.url)),
-        "./out/chat_api_interaction.js"
-    );
+    const sourceFilePath = path.resolve("./src/chat_api_interaction.js");
+    const destinationFilePath = path.resolve("./out/chat_api_interaction.js");
     fs.copyFileSync(sourceFilePath, destinationFilePath);
 } catch (err) {
     console.error("An error occurred during build or file copy:", err);


### PR DESCRIPTION
Ada perubahan pada bagaimana path file ditangani saat proses copy. Sebelumnya, digunakan `path.dirname(fileURLToPath(import.meta.url))` untuk mendapatkan direktori file saat ini, namun sekarang diganti dengan path relatif langsung ke file yang diinginkan.

Perubahan ini dilakukan untuk memperbaiki penanganan path yang sebelumnya tidak berjalan dengan benar.